### PR TITLE
fix: update nightclub offset

### DIFF
--- a/MusinessBanagersource.lua
+++ b/MusinessBanagersource.lua
@@ -1281,7 +1281,7 @@ local function GetNightClubHubOffset()
 end
 
 local function GetNightClubOffset()
-    return (GetOnlineWorkOffset() + 336) -- CLUB_OWNER_X
+    return (GetOnlineWorkOffset() + 354) -- CLUB_OWNER_X
 end
 
 local function GetWarehouseOffset()


### PR DESCRIPTION
`Global_1853988[PLAYER::PLAYER_ID() /*867*/].f_267.f_354` appears to be the correct global.

Fixes "Teleport to Nightclub" and doesn't introduce any regressions from what I can tell. Correct me if I'm wrong, but it seems to work fine with an offset of 354.