### PR TITLE
fix: remove call to deleted commandref

### DIFF
--- a/MusinessBanagersource.lua
+++ b/MusinessBanagersource.lua
@@ -2111,25 +2111,6 @@ if not IS_RELEASE_VERSION then
         end
     end)
 
-    local MBDebug_CEO = menu.list(MBDebug, "CEO Shit", {"mbdebugceo"})
-    for slot = 0, 4 do
-        local property_id = GetWarehousePropertyFromSlot(slot)
-        if property_id ~= 0 then
-            local property_name = WarehousePropertyInfo[property_id].name
-            MenuCurrentWarehouses[slot] = {property_name, {"warehouse"..property_name}, ""}
-        else
-            MenuCurrentWarehouses[slot] = {MenuLabels.SPECIALCARGONOWAREHOUSE, {"warehouse".."invalid"}, MenuLabels.SPECIALCARGONOWAREHOUSE_DESC}
-        end
-    end
-
-    for slot = 0, 4 do
-        local warehouse_list = menu.list(MBDebug_CEO, "Slot "..slot)
-        RegisterUpdatingReadOnlyCommand(warehouse_list, "Property",        function() return MenuCurrentWarehouses[slot][4] or "" end)
-        RegisterUpdatingReadOnlyCommand(warehouse_list, "Property Name",   function() return MenuCurrentWarehouses[slot][1] end)
-        RegisterUpdatingReadOnlyCommand(warehouse_list, "Crates Global",   function() return GetGlobalInt(GetSpecialCargoCrateAmountOffset(slot)) end)
-        RegisterUpdatingReadOnlyCommand(warehouse_list, "Crates Stat",     function() return GetSpecialCargoCrateAmountFromStat(slot) end)
-    end
-
     --menu.action(MBDebug_CEO, "Sync Globals With Stats")
 end
 --------------------------

--- a/MusinessBanagersource.lua
+++ b/MusinessBanagersource.lua
@@ -2123,16 +2123,6 @@ util.create_tick_handler(function()
     if IsInSession() then
         PopulateMyBusinessesTable()
 
-        for slot = 0, 4 do
-            local property_id = GetWarehousePropertyFromSlot(slot)
-            if property_id ~= 0 then
-                local property_name = WarehousePropertyInfo[property_id].name
-                MenuCurrentWarehouses[slot] = {property_name, {"warehouse"..property_name}, "", property_id}
-            else
-                MenuCurrentWarehouses[slot] = {MenuLabels.SPECIALCARGONOWAREHOUSE, {"warehouse".."invalid"}, MenuLabels.SPECIALCARGONOWAREHOUSE_DESC}
-            end
-        end
-
         FixNCHubCapacities()
     end
     return true

--- a/MusinessBanagersource.lua
+++ b/MusinessBanagersource.lua
@@ -2152,8 +2152,6 @@ util.create_tick_handler(function()
             end
         end
 
-        menu.set_list_action_options(WarehouseSelector, MenuCurrentWarehouses)
-
         FixNCHubCapacities()
     end
     return true


### PR DESCRIPTION
`menu.set_list_action_options(WarehouseSelector, MenuCurrentWarehouses)` 

Not really an issue but WarehouseSelector is no longer a valid CommandRef as of 5db08b8, this should resolve the warning. Side note, removed the code that populated ceo warehouse tables, cherry pick them as needed.